### PR TITLE
Update Python modules (internetarchive 5.4.0, pillow 11.3.0, etc.)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ matplotlib = "*"
 numpy = "*"
 pandas = "*"
 plotly = "*"
+pillow = ">=11.3.0"  # Ensure dependency is secure
 Pyarrow = "*"
 Pygments = "*"
 python-dotenv = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f3b43af7d47f204021d61776d16a959e4eac16d2f1bfe191e76172d4c682c057"
+            "sha256": "ffa89d9d058b31c7b28aca6ed62f13f1273b3f8b92f5fa4d279dd3737844d8e8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1470,6 +1470,7 @@
                 "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4",
                 "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==11.3.0"
         },


### PR DESCRIPTION
## Fixes
- 🔴 [internetarchive Vulnerable to Directory Traversal in File.download() · CVE-2025-58438 · GitHub Advisory Database](https://github.com/advisories/GHSA-wx3r-v6h7-frjp) 
- 🟠 [Pillow vulnerability can cause write buffer overflow on BCn encoding · CVE-2025-48379 · GitHub Advisory Database](https://github.com/advisories/GHSA-xg8h-j46f-w952)
- 🟡 [urllib3 does not control redirects in browsers and Node.js · CVE-2025-50182 · GitHub Advisory Database](https://github.com/advisories/GHSA-48p4-8xcf-vxj5)
- 🟡 [urllib3 redirects are not disabled when retries are disabled on PoolManager instantiation · Dependabot alert #43 · creativecommons/quantifying](https://github.com/creativecommons/quantifying/security/dependabot/43)
- 🟡 [Requests vulnerable to .netrc credentials leak via malicious URLs · CVE-2024-47081 · GitHub Advisory Database](https://github.com/advisories/GHSA-9hjg-9r4m-mvj7)

## Description
Update Python modules (internetarchive 5.4.0, pillow 11.3.0, etc.)

## Technical details
```shell
git checkout main
pipenv run pip list > piplist.old
git checkout -b update-python
pipenv update --dev
pipenv run pip list > piplist.new
gsed -e'/^---/d' -i piplist.*
diff -u piplist.old piplist.new
```
(`gsed` is GNU Sed installed via Homebrew. The binary name may simply be `sed` on your system, if you use GNU/Linux.)

```diff
--- piplist.old	2025-10-09 15:33:42
+++ piplist.new	2025-10-09 15:33:42
@@ -1,127 +1,130 @@
 Package                   Version
-anyio                     4.9.0
+anyio                     4.11.0
 appnope                   0.1.4
 argon2-cffi               25.1.0
-argon2-cffi-bindings      21.2.0
+argon2-cffi-bindings      25.1.0
 arrow                     1.3.0
 asttokens                 3.0.0
 async-lru                 2.0.5
-attrs                     25.3.0
+attrs                     25.4.0
 babel                     2.17.0
-beautifulsoup4            4.13.4
-black                     25.1.0
+beautifulsoup4            4.14.2
+black                     25.9.0
 bleach                    6.2.0
-cachetools                5.5.2
-certifi                   2025.4.26
-cffi                      1.17.1
+cachetools                6.2.0
+certifi                   2025.10.5
+cffi                      2.0.0
 cfgv                      3.4.0
-charset-normalizer        3.4.2
-click                     8.2.1
-comm                      0.2.2
-contourpy                 1.3.2
+charset-normalizer        3.4.3
+click                     8.3.0
+comm                      0.2.3
+contourpy                 1.3.3
 cycler                    0.12.1
-debugpy                   1.8.14
+debugpy                   1.8.17
 decorator                 5.2.1
 defusedxml                0.7.1
-distlib                   0.3.9
-executing                 2.2.0
-fastjsonschema            2.21.1
-filelock                  3.18.0
-flake8                    7.2.0
+distlib                   0.4.0
+executing                 2.2.1
+fastjsonschema            2.21.2
+filelock                  3.20.0
+flake8                    7.3.0
 flickrapi                 2.4.0
-fonttools                 4.58.1
+fonttools                 4.60.1
 fqdn                      1.5.1
 gitdb                     4.0.12
-GitPython                 3.1.44
-google-api-core           2.25.0
-google-api-python-client  2.171.0
-google-auth               2.40.3
+GitPython                 3.1.45
+google-api-core           2.26.0
+google-api-python-client  2.184.0
+google-auth               2.41.1
 google-auth-httplib2      0.2.0
 googleapis-common-protos  1.70.0
 h11                       0.16.0
 httpcore                  1.0.9
-httplib2                  0.22.0
+httplib2                  0.31.0
 httpx                     0.28.1
-identify                  2.6.12
+identify                  2.6.15
 idna                      3.10
-internetarchive           5.4.0
-ipykernel                 6.29.5
-ipython                   9.3.0
+internetarchive           5.5.1
+ipykernel                 6.30.1
+ipython                   9.6.0
 ipython_pygments_lexers   1.1.1
 isoduration               20.11.0
-isort                     6.0.1
+isort                     6.1.0
 jedi                      0.19.2
 Jinja2                    3.1.6
-json5                     0.12.0
+json5                     0.12.1
 jsonpatch                 1.33
 jsonpointer               3.0.0
-jsonschema                4.24.0
-jsonschema-specifications 2025.4.1
+jsonschema                4.25.1
+jsonschema-specifications 2025.9.1
 jupyter_client            8.6.3
 jupyter_core              5.8.1
 jupyter-events            0.12.0
-jupyter-lsp               2.2.5
-jupyter_server            2.16.0
+jupyter-lsp               2.3.0
+jupyter_server            2.17.0
 jupyter_server_terminals  0.5.3
-jupyterlab                4.4.3
+jupyterlab                4.4.9
 jupyterlab_pygments       0.3.0
 jupyterlab_server         2.27.3
-kiwisolver                1.4.8
-MarkupSafe                3.0.2
-matplotlib                3.10.3
+kiwisolver                1.4.9
+lark                      1.3.0
+MarkupSafe                3.0.3
+matplotlib                3.10.7
 matplotlib-inline         0.1.7
 mccabe                    0.7.0
-mistune                   3.1.3
+mistune                   3.1.4
 mypy_extensions           1.1.0
-narwhals                  1.41.0
+narwhals                  2.7.0
 nbclient                  0.10.2
 nbconvert                 7.16.6
 nbformat                  5.10.4
 nest-asyncio              1.6.0
 nodeenv                   1.9.1
 notebook_shim             0.2.4
-numpy                     2.2.6
-oauthlib                  3.2.2
+numpy                     2.3.3
+oauthlib                  3.3.1
 overrides                 7.7.0
 packaging                 25.0
-pandas                    2.3.0
+pandas                    2.3.3
 pandocfilters             1.5.1
-parso                     0.8.4
+parso                     0.8.5
 pathspec                  0.12.1
 pexpect                   4.9.0
-pillow                    11.2.1
+pillow                    11.3.0
 pip                       25.1.1
-platformdirs              4.3.8
-plotly                    6.1.2
-pre_commit                4.2.0
-prometheus_client         0.22.1
-prompt_toolkit            3.0.51
+platformdirs              4.5.0
+plotly                    6.3.1
+pre_commit                4.3.0
+prometheus_client         0.23.1
+prompt_toolkit            3.0.52
 proto-plus                1.26.1
-protobuf                  6.31.1
-psutil                    7.0.0
+protobuf                  6.32.1
+psutil                    7.1.0
 ptyprocess                0.7.0
 pure_eval                 0.2.3
-pyarrow                   20.0.0
+pyarrow                   21.0.0
 pyasn1                    0.6.1
 pyasn1_modules            0.4.2
-pycodestyle               2.13.0
-pycparser                 2.22
-pyflakes                  3.3.2
-Pygments                  2.19.1
-pyparsing                 3.2.3
+pycodestyle               2.14.0
+pycparser                 2.23
+pyflakes                  3.4.0
+Pygments                  2.19.2
+pyparsing                 3.2.5
 python-dateutil           2.9.0.post0
-python-dotenv             1.1.0
-python-json-logger        3.3.0
+python-dotenv             1.1.1
+python-json-logger        4.0.0
+pytokens                  0.1.10
 pytz                      2025.2
-PyYAML                    6.0.2
-pyzmq                     26.4.0
+PyYAML                    6.0.3
+pyzmq                     27.1.0
 referencing               0.36.2
-requests                  2.32.3
+requests                  2.32.5
 requests-oauthlib         2.0.0
 requests-toolbelt         1.0.0
 rfc3339-validator         0.1.4
 rfc3986-validator         0.1.1
-rpds-py                   0.25.1
+rfc3987-syntax            1.1.0
+rpds-py                   0.27.1
 rsa                       4.9.1
 seaborn                   0.13.2
 Send2Trash                1.8.3
@@ -129,23 +132,23 @@
 six                       1.17.0
 smmap                     5.0.2
 sniffio                   1.3.1
-soupsieve                 2.7
+soupsieve                 2.8
 stack-data                0.6.3
 terminado                 0.18.1
 tinycss2                  1.4.0
 tokenize_rt               6.2.0
-tornado                   6.5.1
+tornado                   6.5.2
 tqdm                      4.67.1
 traitlets                 5.14.3
-types-python-dateutil     2.9.0.20250516
-typing_extensions         4.14.0
+types-python-dateutil     2.9.0.20251008
+typing_extensions         4.15.0
 tzdata                    2025.2
 uri-template              1.3.0
 uritemplate               4.2.0
-urllib3                   2.4.0
-virtualenv                20.31.2
-wcwidth                   0.2.13
+urllib3                   2.5.0
+virtualenv                20.34.0
+wcwidth                   0.2.14
 webcolors                 24.11.1
 webencodings              0.5.1
-websocket-client          1.8.0
+websocket-client          1.9.0
 wordcloud                 1.9.4
```

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI.
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
