### PR TITLE
[DISCARDED] Add OTL education CSV reader script

### DIFF
--- a/scripts/1-fetch/OTL_education_read_csv.py
+++ b/scripts/1-fetch/OTL_education_read_csv.py
@@ -18,11 +18,9 @@ from pygments import highlight
 from pygments.formatters import TerminalFormatter
 from pygments.lexers import PythonTracebackLexer
 
-# First-party/Local
-import shared
-
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))  # noqa: E402
-
+# First-party/Local
+import shared  # noqa:E402
 
 LOGGER, PATHS = shared.setup(__file__)
 


### PR DESCRIPTION
## Fixes
- Fixes #165 by @Goziee-git

## Description
the `OTL_education_read_csv.py`script reads the pre-automation OTL.csv file and copies it to the current quarter's data directory for processing.

The script:
• Reads from `pre-automation/education/datasets/OTL.csv`
• Copies the data to `data/{quarter}/1-fetch/otl_raw_data.csv`
• Includes proper error handling and logging
• Uses the `--enable-save` flag to control whether data is actually saved
• Follows the project's established patterns for fetch phase scripts

## Technical Note: Script Execution Requirements

Issue: The `OTL_education_read_csv.py` script fails with `ModuleNotFoundError:` No module named `'shared'` when run directly from the 1-fetch directory, necessitating the need for adjusting the need import structure. if import is adjusted, the pre-commit fails.

Root Cause: The script imports the shared module from the parent scripts directory, but Python cannot locate it without proper path configuration.

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [y/n] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI.
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
