### PR TITLE
GitHub fetch: remove double logging of errors

### DIFF
--- a/scripts/1-fetch/github_fetch.py
+++ b/scripts/1-fetch/github_fetch.py
@@ -150,13 +150,10 @@ def query_github(args, session):
             )
             LOGGER.info(f"count: {count}")
         except requests.HTTPError as e:
-            LOGGER.error(f"HTTP Error: {e}")
             raise shared.QuantifyingException(f"HTTP Error: {e}", 1)
         except requests.RequestException as e:
-            LOGGER.error(f"Request Exception: {e}")
             raise shared.QuantifyingException(f"Request Exception: {e}", 1)
         except KeyError as e:
-            LOGGER.error(f"KeyError: {e}.")
             raise shared.QuantifyingException(f"KeyError: {e}", 1)
     return tool_data
 


### PR DESCRIPTION
## Description
GitHub fetch: remove double logging of errors

## Technical details
The end of the script manages error handling. It includes logging of `shared.QuantifyingException`:
https://github.com/creativecommons/quantifying/blob/021e4c4758f881dfc73ae26629dacc429e2b7026/scripts/1-fetch/github_fetch.py#L183-L188

This means that the request error handling will result in two error messages per error:
https://github.com/creativecommons/quantifying/blob/021e4c4758f881dfc73ae26629dacc429e2b7026/scripts/1-fetch/github_fetch.py#L152-L160
1. from LOGGER line
2. from raise line that logs, as mentioned above

Inserting a fake error results in:
```
2025-10-22 08:44:04,166 - ERROR - github_fetch - HTTP Error: test error
2025-10-22 08:44:04,166 - ERROR - github_fetch - HTTP Error: test error
```

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI.
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
