### PR TITLE
Ensure only specified https:// adapter is in session

### DIFF
--- a/scripts/shared.py
+++ b/scripts/shared.py
@@ -37,7 +37,8 @@ class QuantifyingException(Exception):
 
 def get_session(accept_header=None, session=None):
     """
-    Create or configure a reusable HTTPS session with retry logic and headers.
+    Create or configure a reusable HTTPS session with retry logic and
+    appropriate headers.
     """
     if session is None:
         session = Session()
@@ -46,9 +47,11 @@ def get_session(accept_header=None, session=None):
     # (With only a https:// adapter, below, unencrypted requests will fail.)
     session.adapters = OrderedDict()
 
+    # Try again after 0s, 6s, 12s, 24s, 48s (total 90s) for the specified HTTP
+    # error codes (STATUS_FORCELIST)
     retry_strategy = Retry(
         total=5,
-        backoff_factor=10,
+        backoff_factor=3,
         status_forcelist=STATUS_FORCELIST,
         allowed_methods=["GET", "POST"],
         raise_on_status=False,


### PR DESCRIPTION
## Description
Ensure only specified `https://` adapter is in session
- Replace misleading ~~`from requests.adapters import Retry`~~ import
- Prevent HTTP (unencrypted) requests
- Prevent any library's custom Session (ex. `session=ArchiveSession()`) from overriding with less conservative and/or thorough settings
- Reduce `backoff_factor`
- Improve documentation

## Technical details
- [Request Sessions — Developer Interface — Requests documentation](https://docs.python-requests.org/en/latest/api/#request-sessions)
- [`HTTPAdapter` — Developer Interface — Requests documentation](https://docs.python-requests.org/en/latest/api/#requests.adapters.HTTPAdapter)
- [`urllib3.util.Retry` - Utilities - urllib3 documentation](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry)

## Tests
Verified the following scripts work as expected:
- `scripts/1-fetch/europeana_fetch.py`
- `scripts/1-fetch/github_fetch.py`
- `scripts/1-fetch/openverse_fetch.py`
- `scripts/1-fetch/wikipedia_fetch.py`

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI.
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
