### PR TITLE
Fix: Add timeout to network requests to prevent infinite hangs

### DIFF
--- a/scripts/1-fetch/github_fetch.py
+++ b/scripts/1-fetch/github_fetch.py
@@ -95,7 +95,7 @@ def query_github(args, session):
         request_url = f"{base_url}{search_parameters}"
 
         try:
-            with session.get(request_url) as response:
+            with session.get(request_url, timeout=30) as response:
                 response.raise_for_status()
                 search_data = response.json()
                 count = search_data["total_count"]

--- a/scripts/1-fetch/smithsonian_fetch.py
+++ b/scripts/1-fetch/smithsonian_fetch.py
@@ -114,7 +114,7 @@ def query_smithsonian(args, session):
     url = "https://api.si.edu/openaccess/api/v1.0/stats"
     params = {"api_key": DATA_GOV_API_KEY}
     try:
-        with session.get(url, params=params) as response:
+        with session.get(url, params=params, timeout=30) as response:
             response.raise_for_status()
             data = response.json()["response"]
     except requests.HTTPError as e:


### PR DESCRIPTION
This pull request addresses an issue where network requests can cause infinite hangs in CI/CD pipelines. 

**Changes:**
- Added a `timeout=30` parameter to `requests.get()` calls in both `scripts/1-fetch/github_fetch.py` and `scripts/1-fetch/smithsonian_fetch.py`.

**Reasoning:**
By default, Python's `requests` library uses an infinite timeout. If the remote API server accepts a connection but fails to send data, the script will hang forever, waiting for a response and burning pipeline minutes. Setting a 30-second timeout ensures that instead of freezing endlessly, it will raise a timeout exception if the external server becomes unresponsive.